### PR TITLE
Refactor era5cli notebook and check sites against land sea mask

### DIFF
--- a/utils/notebooks/download_era5_data.ipynb
+++ b/utils/notebooks/download_era5_data.ipynb
@@ -73,7 +73,7 @@
    "outputs": [],
    "source": [
     "# Path to land_sea mask file\n",
-    "land_sea_filename = Path(\"/home/sarah/temp/ecoextreml/lsm_1279l4_0.1x0.1.grb_v4_unpack.nc\")"
+    "land_sea_filename = Path(\"./lsm_1279l4_0.1x0.1.grb_v4_unpack.nc\")"
    ]
   },
   {
@@ -83,7 +83,7 @@
    "outputs": [],
    "source": [
     "# path to forcing data, for example on CRIB data are located at:\n",
-    "forcing_path = Path(\"/home/sarah/temp/ecoextreml/data/forcing/plumber2_data/\")"
+    "forcing_path = Path(\"/data/shared/EcoExtreML/STEMMUS_SCOPEv1.0.0/input/Plumber2_data/\")"
    ]
   },
   {
@@ -373,7 +373,7 @@
    "outputs": [],
    "source": [
     "## specify the forcing file names or set fullrun = True\n",
-    "forcing_filenames_list = [\"AR-SLu_2010-2010_FLUXNET2015_Met.nc\", \"AU-ASM_2011-2017_OzFlux_Met.nc\", ]\n",
+    "forcing_filenames_list = [\"AR-SLu_2010-2010_FLUXNET2015_Met.nc\", \"AU-ASM_2011-2017_OzFlux_Met.nc\"]\n",
     "\n",
     "## if you want to download all 170 sites, change fullrun = False to fullrun = True\n",
     "fullrun = False\n",


### PR DESCRIPTION
This pull request fixes the notebooks for downloading era5 data. It checks missing values and picks the nearest grid cell to the site location.