### PR TITLE
Add git-blame-ingnore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# Formatted all matlab code with HITMISS
+6832a3007d6ca683269a7235b277b3c5bb86161f


### PR DESCRIPTION
With #147 almost all matlab code was modified using the HITMISS formatter. However, this makes `git blame` less useful.
This PR adds a file in which specific commits can be ignored in the blame history.

For easy comparison (left is this branch, right is main):
![image](https://user-images.githubusercontent.com/12114825/225014141-f91b7114-6676-49d8-ab10-e3b5be9d5a2c.png)
