### PR TITLE
Fix Octave dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,7 @@
-FROM gnuoctave/octave:7.2.0
+FROM gnuoctave/octave:8.1.0
 
-RUN octave --eval 'pkg install -forge statistics'
+RUN octave --eval 'pkg install -forge io'
+RUN octave --eval 'pkg install "https://octave.sourceforge.io/download.php?package=statistics-1.4.3.tar.gz"'
 RUN apt update && apt install -yq libnetcdf-dev && octave --eval 'pkg install -forge netcdf'
 
 ARG USERNAME=octave

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,11 +5,7 @@ FROM gnuoctave/octave:8.1.0
 #
 # IO is a dependency of statistics, needs to be installed first.
 RUN octave --eval 'pkg install "https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Individual%20Package%20Releases/io-2.6.4.tar.gz"'
-RUN octave --eval 'pkg install "https://octave.sourceforge.io/download.php?package=statistics-1.4.3.tar.gz"'
-
-# Install netcdf dependencies first.
-RUN apt update && apt install -yq libnetcdf-dev
-RUN octave --eval 'pkg install "https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Individual%20Package%20Releases/netcdf-1.0.16.tar.gz"'
+RUN octave --eval 'pkg install "https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Individual%20Package%20Releases/statistics-1.4.3.tar.gz"'
 
 ARG USERNAME=octave
 ARG USER_UID=1000

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM gnuoctave/octave:8.1.0
 
-RUN octave --eval 'pkg install -forge io'
+RUN octave --eval 'pkg install "https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Individual%20Package%20Releases/io-2.6.4.tar.gz"'
 RUN octave --eval 'pkg install "https://octave.sourceforge.io/download.php?package=statistics-1.4.3.tar.gz"'
 RUN apt update && apt install -yq libnetcdf-dev && octave --eval 'pkg install -forge netcdf'
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,15 @@
 FROM gnuoctave/octave:8.1.0
 
+# NOTE: all package version are pinned to avoid the container breaking with the 
+#     latest version on octave's forge.
+#
+# IO is a dependency of statistics, needs to be installed first.
 RUN octave --eval 'pkg install "https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Individual%20Package%20Releases/io-2.6.4.tar.gz"'
 RUN octave --eval 'pkg install "https://octave.sourceforge.io/download.php?package=statistics-1.4.3.tar.gz"'
-RUN apt update && apt install -yq libnetcdf-dev && octave --eval 'pkg install -forge netcdf'
+
+# Install netcdf dependencies first.
+RUN apt update && apt install -yq libnetcdf-dev
+RUN octave --eval 'pkg install "https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Individual%20Package%20Releases/netcdf-1.0.16.tar.gz"'
 
 ARG USERNAME=octave
 ARG USER_UID=1000


### PR DESCRIPTION
- [x] Pin octave statistics to 1.4.3.
- [x] Bump octave to 8.1.0
- [x] Pin octave IO to 2.6.4
- [x] ~~Pin octave netcdf to 1.0.16~~
- [x] Remove octave-netcdf

Tested with main branch code: no issues found, everything runs fine.

The fix was outlined in #135. IO is a dependency, and has to be installed separately first.
I pinned io and netcdf to make sure that the docker container won't break in the future.