### PR TITLE
Pin docker source with SHA

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM gnuoctave/octave:8.1.0
+FROM gnuoctave/octave:8.1.0@sha256:bb4eebf2e72e49c7bc564120843219f13c53396a515e1d7a00e99baea0c651fd
 
 # NOTE: all package version are pinned to avoid the container breaking with the 
 #     latest version on octave's forge.


### PR DESCRIPTION
Based on the comments from @sverhoeven , this PR pins the docker image using the current SHA. This should avoid any unexpected and/or unwanted changes.
Reason for this is that [_all_ octave docker images were recently changed](https://hub.docker.com/r/gnuoctave/octave/tags), not just the latest versions.

I tested the dockerfile by (succesfully) rebuilding the container. The docker image did not change in the last two months so it should still be able to run STEMMUS_SCOPE without any issues.