### PR TITLE
Add dockerfile, bump version to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,26 @@
 # Unreleased
 
+<a name="1.5.0"></a>
+# [1.5.0](https://github.com/EcoExtreML/STEMMUS_SCOPE/releases/tag/1.5.0) - 3 Jan 2024
+
+This version of STEMMUS_SCOPE is only compatible with [PyStemmusScope 0.3.0.](https://github.com/EcoExtreML/STEMMUS_SCOPE_Processing/releases/tag/v0.3.0)
+
 **Changed:**
-- The STEMMUS_SCOPE Matlab Runtime executable now needs version `R2023a`.
+
+- The STEMMUS_SCOPE Matlab Runtime executable now needs version `R2023a` ([#208](https://github.com/EcoExtreML/STEMMUS_SCOPE/pull/208)).
 
 **Added:**
-- STEMMUS_SCOPE BMI preparation:
+
+- STEMMUS_SCOPE 'BMI'-like mode ([#208](https://github.com/EcoExtreML/STEMMUS_SCOPE/pull/208)):
   - The executable can be run in an "interactive" mode. 
     In this mode the model's initialization, time update, and finalization can be called upon separately.
   - The model now will write away BMI-required variables to a state file, which can be used for the Python BMI.
+- A dockerfile for the BMI-enabled STEMMUS_SCOPE model, to make the setup easier.
 
 **Fixed:**
 
 - use `any()` function in `solveTridiagonalMatrixEquations.m` in
-  [203](https://github.com/EcoExtreML/STEMMUS_SCOPE/pull/203)
+  [#203](https://github.com/EcoExtreML/STEMMUS_SCOPE/pull/203)
 
 
 <a name="1.4.0"></a>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM demartis/matlab-runtime:R2023a@sha256:9d6b3acd29b974ca0a0c77eca09a34488dcece290c8a4bd04dafaa7c4a5665b2
 LABEL maintainer="Bart Schilperoort <b.schilperoort@esciencecenter.nl>"
 
-# TODO: update from BMI branch to main
 RUN wget https://github.com/EcoExtreML/STEMMUS_SCOPE/raw/main/run_model_on_snellius/exe/STEMMUS_SCOPE --no-check-certificate
 
 # Make sure the file is executable
 RUN chmod +x STEMMUS_SCOPE
 
 CMD ./STEMMUS_SCOPE "" bmi
-# Start with the command 'docker run -it stemmus_scope'
+# Build the image with: `docker build . -t stemmus_scope`
+# Then start with the command `docker run -it stemmus_scope`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM demartis/matlab-runtime:R2023a@sha256:9d6b3acd29b974ca0a0c77eca09a34488dcece290c8a4bd04dafaa7c4a5665b2
+LABEL maintainer="Bart Schilperoort <b.schilperoort@esciencecenter.nl>"
+
+# TODO: update from BMI branch to main
+RUN wget https://github.com/EcoExtreML/STEMMUS_SCOPE/raw/main/run_model_on_snellius/exe/STEMMUS_SCOPE --no-check-certificate
+
+# Make sure the file is executable
+RUN chmod +x STEMMUS_SCOPE
+
+CMD ./STEMMUS_SCOPE "" bmi
+# Start with the command 'docker run -it stemmus_scope'


### PR DESCRIPTION
A dockerfile has been added, this will allow for publishing a ["package"](https://github.com/orgs/EcoExtreML/packages?repo_name=STEMMUS_SCOPE) on Github.

The version has been bumped to 1.5.0. This way the Docker image's version can be set to 1.5.0, matching the release of the source code.